### PR TITLE
Relative container for positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Docs
 - **animateFade**: If `TRUE` (default) animate the dropdown menu appearance.
 - **legacyEvents**: If `TRUE` fires "change" event for the original `<select>` element.
 - **fx**: An object for additional `Fx` options (default `{'duration': 'short'}`).
+- **relativeTo**: An element id or element reference for dropdown positioning. (default `document.body`).
 
 **Events:**
 

--- a/Source/FancySelect.js
+++ b/Source/FancySelect.js
@@ -29,7 +29,8 @@ var FancySelect = new Class({
 		autoScrollWindow: false,
 		animateFade: true,
 		animateSlide: true,
-		fx: { 'duration': 'short' }
+		fx: { 'duration': 'short' },
+		relativeTo: document.body
 	},
 
 	initialize: function(element, options) {
@@ -119,7 +120,7 @@ var FancySelect = new Class({
 
 	show: function() {
 		var offset = this.options.offset;
-		var position = this.div.getCoordinates();
+		var position = this.div.getCoordinates(this.options.relativeTo);
 		this.ul.setStyles({
 			'top': position.top + position.height + offset.y,
 			'left': position.left + offset.x });


### PR DESCRIPTION
Sometimes you want your elements in absolutely/relatively positioned containers, like lightboxes or other modal windows. This fix utilizes the positioning via mootools api (element passed in as option to getCoordinates) to fix the positioning easily.
